### PR TITLE
fix: aceitar login tanto em localhost quanto em 127.0.0.1

### DIFF
--- a/projeto_integrador/api.js
+++ b/projeto_integrador/api.js
@@ -96,7 +96,12 @@
   function baseLocalPadrao() {
     const host = location.hostname;
     const ehLocal = !host || host === 'localhost' || host === '127.0.0.1';
-    if (ehLocal && location.port !== '8080') return 'http://localhost:8080';
+    // Usa o mesmo hostname da pagina (localhost OU 127.0.0.1) para que o
+    // cookie de sessao seja considerado same-site e enviado nas requisicoes.
+    if (ehLocal && location.port !== '8080') {
+      const hostnameApi = host || 'localhost';
+      return 'http://' + hostnameApi + ':8080';
+    }
     return '';
   }
 

--- a/projeto_integrador/config.js
+++ b/projeto_integrador/config.js
@@ -5,7 +5,21 @@
   const LEGACY_API_BASE_KEY = 'EVALUASOFT_API_BASE_URL';
   const READY_KEY = 'SOFTGROUP_CONFIG_READY';
   const LEGACY_READY_KEY = 'EVALUASOFT_CONFIG_READY';
-  const DEFAULT_API_BASE_URL = 'http://localhost:8080';
+  const DEFAULT_API_BASE_URL = calcularDefaultApiBase();
+
+  function calcularDefaultApiBase() {
+    try {
+      const host = (global.location && global.location.hostname) || '';
+      // Quando o frontend roda em localhost OU 127.0.0.1, espelha o mesmo
+      // hostname para a API. Isso evita que o cookie de sessao caia em
+      // "cross-site" (localhost vs 127.0.0.1 sao tratados como sites
+      // diferentes pelo navegador) e seja bloqueado pelo SameSite=Lax.
+      if (host === 'localhost' || host === '127.0.0.1') {
+        return 'http://' + host + ':8080';
+      }
+    } catch (_) {}
+    return 'http://localhost:8080';
+  }
 
   const ready = carregarEnv();
   global[READY_KEY] = ready;


### PR DESCRIPTION
Antes, a URL base da API era fixa em http://localhost:8080. Quando o frontend era servido em http://127.0.0.1:5500 (padrao do Live Server), o navegador tratava as duas origens como sites diferentes e bloqueava o cookie de sessao (SameSite=Lax) nas requisicoes seguintes, fazendo o usuario voltar para a tela de login mesmo apos autenticar.

Agora a URL da API espelha o hostname da pagina (localhost ou 127.0.0.1), mantendo a requisicao same-site e permitindo que o cookie de sessao seja enviado normalmente.