### PR TITLE
feat: adiciona responsividade aos arquivos CSS

### DIFF
--- a/projeto_integrador/admin/avaliacoes.css
+++ b/projeto_integrador/admin/avaliacoes.css
@@ -226,3 +226,62 @@ body { background-color: var(--bg-color); color: var(--text-dark); display: flex
   gap: 12px;
   margin-top: 8px;
 }
+
+/* ============================================================
+   RESPONSIVIDADE
+   Adapta o layout para tablet, notebook e celular mantendo o
+   design original (cores, cartoes e tipografia). Usa !important
+   apenas para sobrepor grids definidos via style inline no HTML.
+   ============================================================ */
+
+/* Notebook / telas medias */
+@media (max-width: 1024px) {
+  :root { --sidebar-width: 190px; }
+  .dashboard-content { padding: 24px; }
+  .stats-row { grid-template-columns: repeat(2, 1fr) !important; }
+  .main-grid { grid-template-columns: 1fr !important; }
+  .busca { width: 200px; }
+}
+
+/* Tablet */
+@media (max-width: 768px) {
+  body { display: block; height: auto; min-height: 100vh; overflow-x: hidden; }
+  .app-container { flex-direction: column; width: 100%; }
+
+  /* Sidebar vira uma barra de navegacao no topo */
+  .sidebar {
+    width: 100%;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    padding: 12px 16px;
+    border-right: none;
+    border-bottom: 1px solid var(--border-color);
+  }
+  .logo { margin-bottom: 0; padding: 0; }
+  .menu { flex-direction: row; flex: 1 1 100%; overflow-x: auto; gap: 4px; margin-top: 10px; padding-bottom: 4px; }
+  .menu a { margin: 0; white-space: nowrap; flex: 0 0 auto; }
+  .indicador { display: none; }
+  .sidebar-footer { flex-direction: row; align-items: center; padding: 0; margin-left: auto; gap: 8px; }
+  .sidebar-footer .btn-novo { margin-bottom: 0; white-space: nowrap; }
+
+  .main-content { overflow: visible; }
+  .topbar { height: auto; flex-wrap: wrap; gap: 12px; padding: 16px; }
+  .topbar-left, .topbar-right { gap: 12px; flex-wrap: wrap; }
+  .busca { width: 100%; }
+
+  .dashboard-content { padding: 16px; }
+  .stats-row { grid-template-columns: repeat(2, 1fr) !important; gap: 16px; }
+  .insights-row { grid-template-columns: 1fr !important; }
+
+  .painel-notificacoes { top: auto; right: 16px; left: 16px; width: auto; }
+  .modal-backdrop { padding: 16px; }
+}
+
+/* Celular */
+@media (max-width: 480px) {
+  .stats-row { grid-template-columns: 1fr !important; }
+  .topbar-left h2 { font-size: 16px; }
+  .stat-value { font-size: 24px; }
+  .busca { padding: 8px 12px; }
+}

--- a/projeto_integrador/admin/colaboradores.css
+++ b/projeto_integrador/admin/colaboradores.css
@@ -155,3 +155,62 @@ body { background-color: var(--bg-color); color: var(--text-dark); display: flex
 
 .btn-outline { background-color: transparent; border: 1px solid var(--border-color); padding: 12px; width: calc(100% - 48px); margin: 0 24px 24px; border-radius: 8px; font-weight: 600; color: var(--text-dark); font-size: 13px; cursor: pointer; transition: 0.2s;}
 .btn-outline:hover { background-color: #f9fafb; border-color: #d1d5db; }
+
+/* ============================================================
+   RESPONSIVIDADE
+   Adapta o layout para tablet, notebook e celular mantendo o
+   design original (cores, cartoes e tipografia). Usa !important
+   apenas para sobrepor grids definidos via style inline no HTML.
+   ============================================================ */
+
+/* Notebook / telas medias */
+@media (max-width: 1024px) {
+  :root { --sidebar-width: 190px; }
+  .dashboard-content { padding: 24px; }
+  .stats-row { grid-template-columns: repeat(2, 1fr) !important; }
+  .main-grid { grid-template-columns: 1fr !important; }
+  .busca { width: 200px; }
+}
+
+/* Tablet */
+@media (max-width: 768px) {
+  body { display: block; height: auto; min-height: 100vh; overflow-x: hidden; }
+  .app-container { flex-direction: column; width: 100%; }
+
+  /* Sidebar vira uma barra de navegacao no topo */
+  .sidebar {
+    width: 100%;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    padding: 12px 16px;
+    border-right: none;
+    border-bottom: 1px solid var(--border-color);
+  }
+  .logo { margin-bottom: 0; padding: 0; }
+  .menu { flex-direction: row; flex: 1 1 100%; overflow-x: auto; gap: 4px; margin-top: 10px; padding-bottom: 4px; }
+  .menu a { margin: 0; white-space: nowrap; flex: 0 0 auto; }
+  .indicador { display: none; }
+  .sidebar-footer { flex-direction: row; align-items: center; padding: 0; margin-left: auto; gap: 8px; }
+  .sidebar-footer .btn-novo { margin-bottom: 0; white-space: nowrap; }
+
+  .main-content { overflow: visible; }
+  .topbar { height: auto; flex-wrap: wrap; gap: 12px; padding: 16px; }
+  .topbar-left, .topbar-right { gap: 12px; flex-wrap: wrap; }
+  .busca { width: 100%; }
+
+  .dashboard-content { padding: 16px; }
+  .stats-row { grid-template-columns: repeat(2, 1fr) !important; gap: 16px; }
+  .insights-row { grid-template-columns: 1fr !important; }
+
+  .painel-notificacoes { top: auto; right: 16px; left: 16px; width: auto; }
+  .modal-backdrop { padding: 16px; }
+}
+
+/* Celular */
+@media (max-width: 480px) {
+  .stats-row { grid-template-columns: 1fr !important; }
+  .topbar-left h2 { font-size: 16px; }
+  .stat-value { font-size: 24px; }
+  .busca { padding: 8px 12px; }
+}

--- a/projeto_integrador/admin/configuracoes.css
+++ b/projeto_integrador/admin/configuracoes.css
@@ -155,3 +155,62 @@ body { background-color: var(--bg-color); color: var(--text-dark); display: flex
 
 .btn-outline { background-color: transparent; border: 1px solid var(--border-color); padding: 12px; width: calc(100% - 48px); margin: 0 24px 24px; border-radius: 8px; font-weight: 600; color: var(--text-dark); font-size: 13px; cursor: pointer; transition: 0.2s;}
 .btn-outline:hover { background-color: #f9fafb; border-color: #d1d5db; }
+
+/* ============================================================
+   RESPONSIVIDADE
+   Adapta o layout para tablet, notebook e celular mantendo o
+   design original (cores, cartoes e tipografia). Usa !important
+   apenas para sobrepor grids definidos via style inline no HTML.
+   ============================================================ */
+
+/* Notebook / telas medias */
+@media (max-width: 1024px) {
+  :root { --sidebar-width: 190px; }
+  .dashboard-content { padding: 24px; }
+  .stats-row { grid-template-columns: repeat(2, 1fr) !important; }
+  .main-grid { grid-template-columns: 1fr !important; }
+  .busca { width: 200px; }
+}
+
+/* Tablet */
+@media (max-width: 768px) {
+  body { display: block; height: auto; min-height: 100vh; overflow-x: hidden; }
+  .app-container { flex-direction: column; width: 100%; }
+
+  /* Sidebar vira uma barra de navegacao no topo */
+  .sidebar {
+    width: 100%;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    padding: 12px 16px;
+    border-right: none;
+    border-bottom: 1px solid var(--border-color);
+  }
+  .logo { margin-bottom: 0; padding: 0; }
+  .menu { flex-direction: row; flex: 1 1 100%; overflow-x: auto; gap: 4px; margin-top: 10px; padding-bottom: 4px; }
+  .menu a { margin: 0; white-space: nowrap; flex: 0 0 auto; }
+  .indicador { display: none; }
+  .sidebar-footer { flex-direction: row; align-items: center; padding: 0; margin-left: auto; gap: 8px; }
+  .sidebar-footer .btn-novo { margin-bottom: 0; white-space: nowrap; }
+
+  .main-content { overflow: visible; }
+  .topbar { height: auto; flex-wrap: wrap; gap: 12px; padding: 16px; }
+  .topbar-left, .topbar-right { gap: 12px; flex-wrap: wrap; }
+  .busca { width: 100%; }
+
+  .dashboard-content { padding: 16px; }
+  .stats-row { grid-template-columns: repeat(2, 1fr) !important; gap: 16px; }
+  .insights-row { grid-template-columns: 1fr !important; }
+
+  .painel-notificacoes { top: auto; right: 16px; left: 16px; width: auto; }
+  .modal-backdrop { padding: 16px; }
+}
+
+/* Celular */
+@media (max-width: 480px) {
+  .stats-row { grid-template-columns: 1fr !important; }
+  .topbar-left h2 { font-size: 16px; }
+  .stat-value { font-size: 24px; }
+  .busca { padding: 8px 12px; }
+}

--- a/projeto_integrador/admin/relatorios.css
+++ b/projeto_integrador/admin/relatorios.css
@@ -155,3 +155,62 @@ body { background-color: var(--bg-color); color: var(--text-dark); display: flex
 
 .btn-outline { background-color: transparent; border: 1px solid var(--border-color); padding: 12px; width: calc(100% - 48px); margin: 0 24px 24px; border-radius: 8px; font-weight: 600; color: var(--text-dark); font-size: 13px; cursor: pointer; transition: 0.2s;}
 .btn-outline:hover { background-color: #f9fafb; border-color: #d1d5db; }
+
+/* ============================================================
+   RESPONSIVIDADE
+   Adapta o layout para tablet, notebook e celular mantendo o
+   design original (cores, cartoes e tipografia). Usa !important
+   apenas para sobrepor grids definidos via style inline no HTML.
+   ============================================================ */
+
+/* Notebook / telas medias */
+@media (max-width: 1024px) {
+  :root { --sidebar-width: 190px; }
+  .dashboard-content { padding: 24px; }
+  .stats-row { grid-template-columns: repeat(2, 1fr) !important; }
+  .main-grid { grid-template-columns: 1fr !important; }
+  .busca { width: 200px; }
+}
+
+/* Tablet */
+@media (max-width: 768px) {
+  body { display: block; height: auto; min-height: 100vh; overflow-x: hidden; }
+  .app-container { flex-direction: column; width: 100%; }
+
+  /* Sidebar vira uma barra de navegacao no topo */
+  .sidebar {
+    width: 100%;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    padding: 12px 16px;
+    border-right: none;
+    border-bottom: 1px solid var(--border-color);
+  }
+  .logo { margin-bottom: 0; padding: 0; }
+  .menu { flex-direction: row; flex: 1 1 100%; overflow-x: auto; gap: 4px; margin-top: 10px; padding-bottom: 4px; }
+  .menu a { margin: 0; white-space: nowrap; flex: 0 0 auto; }
+  .indicador { display: none; }
+  .sidebar-footer { flex-direction: row; align-items: center; padding: 0; margin-left: auto; gap: 8px; }
+  .sidebar-footer .btn-novo { margin-bottom: 0; white-space: nowrap; }
+
+  .main-content { overflow: visible; }
+  .topbar { height: auto; flex-wrap: wrap; gap: 12px; padding: 16px; }
+  .topbar-left, .topbar-right { gap: 12px; flex-wrap: wrap; }
+  .busca { width: 100%; }
+
+  .dashboard-content { padding: 16px; }
+  .stats-row { grid-template-columns: repeat(2, 1fr) !important; gap: 16px; }
+  .insights-row { grid-template-columns: 1fr !important; }
+
+  .painel-notificacoes { top: auto; right: 16px; left: 16px; width: auto; }
+  .modal-backdrop { padding: 16px; }
+}
+
+/* Celular */
+@media (max-width: 480px) {
+  .stats-row { grid-template-columns: 1fr !important; }
+  .topbar-left h2 { font-size: 16px; }
+  .stat-value { font-size: 24px; }
+  .busca { padding: 8px 12px; }
+}

--- a/projeto_integrador/admin/style.css
+++ b/projeto_integrador/admin/style.css
@@ -191,3 +191,62 @@ body { background-color: var(--bg-color); color: var(--text-dark); display: flex
 }
 .modal input:focus, .modal select:focus, .modal textarea:focus { border-color: var(--primary); }
 .modal-acoes { display: flex; gap: 12px; justify-content: flex-end; margin-top: 8px; }
+
+/* ============================================================
+   RESPONSIVIDADE
+   Adapta o layout para tablet, notebook e celular mantendo o
+   design original (cores, cartoes e tipografia). Usa !important
+   apenas para sobrepor grids definidos via style inline no HTML.
+   ============================================================ */
+
+/* Notebook / telas medias */
+@media (max-width: 1024px) {
+  :root { --sidebar-width: 190px; }
+  .dashboard-content { padding: 24px; }
+  .stats-row { grid-template-columns: repeat(2, 1fr) !important; }
+  .main-grid { grid-template-columns: 1fr !important; }
+  .busca { width: 200px; }
+}
+
+/* Tablet */
+@media (max-width: 768px) {
+  body { display: block; height: auto; min-height: 100vh; overflow-x: hidden; }
+  .app-container { flex-direction: column; width: 100%; }
+
+  /* Sidebar vira uma barra de navegacao no topo */
+  .sidebar {
+    width: 100%;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    padding: 12px 16px;
+    border-right: none;
+    border-bottom: 1px solid var(--border-color);
+  }
+  .logo { margin-bottom: 0; padding: 0; }
+  .menu { flex-direction: row; flex: 1 1 100%; overflow-x: auto; gap: 4px; margin-top: 10px; padding-bottom: 4px; }
+  .menu a { margin: 0; white-space: nowrap; flex: 0 0 auto; }
+  .indicador { display: none; }
+  .sidebar-footer { flex-direction: row; align-items: center; padding: 0; margin-left: auto; gap: 8px; }
+  .sidebar-footer .btn-novo { margin-bottom: 0; white-space: nowrap; }
+
+  .main-content { overflow: visible; }
+  .topbar { height: auto; flex-wrap: wrap; gap: 12px; padding: 16px; }
+  .topbar-left, .topbar-right { gap: 12px; flex-wrap: wrap; }
+  .busca { width: 100%; }
+
+  .dashboard-content { padding: 16px; }
+  .stats-row { grid-template-columns: repeat(2, 1fr) !important; gap: 16px; }
+  .insights-row { grid-template-columns: 1fr !important; }
+
+  .painel-notificacoes { top: auto; right: 16px; left: 16px; width: auto; }
+  .modal-backdrop { padding: 16px; }
+}
+
+/* Celular */
+@media (max-width: 480px) {
+  .stats-row { grid-template-columns: 1fr !important; }
+  .topbar-left h2 { font-size: 16px; }
+  .stat-value { font-size: 24px; }
+  .busca { padding: 8px 12px; }
+}

--- a/projeto_integrador/colaborador/avaliacoes.css
+++ b/projeto_integrador/colaborador/avaliacoes.css
@@ -379,3 +379,61 @@ body {
   background-color: var(--fundo-lateral);
   border-radius: 0 0 12px 12px;
 }
+
+/* ============================================================
+   RESPONSIVIDADE
+   Adapta o layout para tablet, notebook e celular mantendo o
+   design original. Cobre todas as grades usadas nas paginas de
+   colaborador e lider (.grade-painel, .grade-kpi, .dashboard-grid,
+   .stats-grid) e os modais.
+   ============================================================ */
+
+/* Notebook / telas medias */
+@media (max-width: 1024px) {
+  .conteudo-principal { padding: 24px 28px; }
+  .grade-painel,
+  .dashboard-grid { grid-template-columns: 1fr; }
+  .grade-kpi { grid-template-columns: repeat(2, 1fr); }
+}
+
+/* Tablet */
+@media (max-width: 768px) {
+  body { height: auto; }
+  .conteiner-app { flex-direction: column; height: auto; min-height: 100vh; }
+
+  /* Barra lateral vira navegacao no topo */
+  .barra-lateral {
+    width: 100%;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    padding: 12px 16px;
+    border-right: none;
+    border-bottom: 1px solid var(--borda);
+  }
+  .logotipo { padding: 0; }
+  .menu-navegacao { flex-direction: row; flex: 1 1 100%; overflow-x: auto; gap: 4px; margin-top: 10px; padding-bottom: 4px; }
+  .item-navegacao { margin: 0; white-space: nowrap; flex: 0 0 auto; }
+  .btn-novo { margin: 0 0 0 auto; width: auto; white-space: nowrap; }
+  .menu-inferior { border-top: none; padding-top: 0; }
+
+  .conteudo-principal { padding: 16px; overflow: visible; }
+  .barra-superior { flex-wrap: wrap; gap: 12px; }
+  .barra-superior-esq,
+  .barra-superior-dir { gap: 12px; flex-wrap: wrap; }
+
+  .grade-painel,
+  .dashboard-grid,
+  .grade-kpi,
+  .stats-grid { grid-template-columns: 1fr; }
+
+  /* Modais ocupam a tela com margem */
+  .modal-fundo { padding: 16px; }
+  .modal-conteudo { max-height: 90vh; overflow-y: auto; }
+}
+
+/* Celular */
+@media (max-width: 480px) {
+  .stats-grid { grid-template-columns: 1fr 1fr; }
+  .barra-superior-esq h1 { font-size: 1.25rem; }
+}

--- a/projeto_integrador/colaborador/dashboard.css
+++ b/projeto_integrador/colaborador/dashboard.css
@@ -385,3 +385,60 @@ body {
   align-items: center;
   gap: 6px;
 }
+/* ============================================================
+   RESPONSIVIDADE
+   Adapta o layout para tablet, notebook e celular mantendo o
+   design original. Cobre todas as grades usadas nas paginas de
+   colaborador e lider (.grade-painel, .grade-kpi, .dashboard-grid,
+   .stats-grid) e os modais.
+   ============================================================ */
+
+/* Notebook / telas medias */
+@media (max-width: 1024px) {
+  .conteudo-principal { padding: 24px 28px; }
+  .grade-painel,
+  .dashboard-grid { grid-template-columns: 1fr; }
+  .grade-kpi { grid-template-columns: repeat(2, 1fr); }
+}
+
+/* Tablet */
+@media (max-width: 768px) {
+  body { height: auto; }
+  .conteiner-app { flex-direction: column; height: auto; min-height: 100vh; }
+
+  /* Barra lateral vira navegacao no topo */
+  .barra-lateral {
+    width: 100%;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    padding: 12px 16px;
+    border-right: none;
+    border-bottom: 1px solid var(--borda);
+  }
+  .logotipo { padding: 0; }
+  .menu-navegacao { flex-direction: row; flex: 1 1 100%; overflow-x: auto; gap: 4px; margin-top: 10px; padding-bottom: 4px; }
+  .item-navegacao { margin: 0; white-space: nowrap; flex: 0 0 auto; }
+  .btn-novo { margin: 0 0 0 auto; width: auto; white-space: nowrap; }
+  .menu-inferior { border-top: none; padding-top: 0; }
+
+  .conteudo-principal { padding: 16px; overflow: visible; }
+  .barra-superior { flex-wrap: wrap; gap: 12px; }
+  .barra-superior-esq,
+  .barra-superior-dir { gap: 12px; flex-wrap: wrap; }
+
+  .grade-painel,
+  .dashboard-grid,
+  .grade-kpi,
+  .stats-grid { grid-template-columns: 1fr; }
+
+  /* Modais ocupam a tela com margem */
+  .modal-fundo { padding: 16px; }
+  .modal-conteudo { max-height: 90vh; overflow-y: auto; }
+}
+
+/* Celular */
+@media (max-width: 480px) {
+  .stats-grid { grid-template-columns: 1fr 1fr; }
+  .barra-superior-esq h1 { font-size: 1.25rem; }
+}

--- a/projeto_integrador/colaborador/index.css
+++ b/projeto_integrador/colaborador/index.css
@@ -358,3 +358,61 @@ body {
   color: var(--primaria);
   font-weight: 600;
 }
+
+/* ============================================================
+   RESPONSIVIDADE
+   Adapta o layout para tablet, notebook e celular mantendo o
+   design original. Cobre todas as grades usadas nas paginas de
+   colaborador e lider (.grade-painel, .grade-kpi, .dashboard-grid,
+   .stats-grid) e os modais.
+   ============================================================ */
+
+/* Notebook / telas medias */
+@media (max-width: 1024px) {
+  .conteudo-principal { padding: 24px 28px; }
+  .grade-painel,
+  .dashboard-grid { grid-template-columns: 1fr; }
+  .grade-kpi { grid-template-columns: repeat(2, 1fr); }
+}
+
+/* Tablet */
+@media (max-width: 768px) {
+  body { height: auto; }
+  .conteiner-app { flex-direction: column; height: auto; min-height: 100vh; }
+
+  /* Barra lateral vira navegacao no topo */
+  .barra-lateral {
+    width: 100%;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    padding: 12px 16px;
+    border-right: none;
+    border-bottom: 1px solid var(--borda);
+  }
+  .logotipo { padding: 0; }
+  .menu-navegacao { flex-direction: row; flex: 1 1 100%; overflow-x: auto; gap: 4px; margin-top: 10px; padding-bottom: 4px; }
+  .item-navegacao { margin: 0; white-space: nowrap; flex: 0 0 auto; }
+  .btn-novo { margin: 0 0 0 auto; width: auto; white-space: nowrap; }
+  .menu-inferior { border-top: none; padding-top: 0; }
+
+  .conteudo-principal { padding: 16px; overflow: visible; }
+  .barra-superior { flex-wrap: wrap; gap: 12px; }
+  .barra-superior-esq,
+  .barra-superior-dir { gap: 12px; flex-wrap: wrap; }
+
+  .grade-painel,
+  .dashboard-grid,
+  .grade-kpi,
+  .stats-grid { grid-template-columns: 1fr; }
+
+  /* Modais ocupam a tela com margem */
+  .modal-fundo { padding: 16px; }
+  .modal-conteudo { max-height: 90vh; overflow-y: auto; }
+}
+
+/* Celular */
+@media (max-width: 480px) {
+  .stats-grid { grid-template-columns: 1fr 1fr; }
+  .barra-superior-esq h1 { font-size: 1.25rem; }
+}

--- a/projeto_integrador/colaborador/relatorios.css
+++ b/projeto_integrador/colaborador/relatorios.css
@@ -268,3 +268,60 @@ body {
 }
 
 .controle-formulario:focus { border-color: var(--primaria); }
+/* ============================================================
+   RESPONSIVIDADE
+   Adapta o layout para tablet, notebook e celular mantendo o
+   design original. Cobre todas as grades usadas nas paginas de
+   colaborador e lider (.grade-painel, .grade-kpi, .dashboard-grid,
+   .stats-grid) e os modais.
+   ============================================================ */
+
+/* Notebook / telas medias */
+@media (max-width: 1024px) {
+  .conteudo-principal { padding: 24px 28px; }
+  .grade-painel,
+  .dashboard-grid { grid-template-columns: 1fr; }
+  .grade-kpi { grid-template-columns: repeat(2, 1fr); }
+}
+
+/* Tablet */
+@media (max-width: 768px) {
+  body { height: auto; }
+  .conteiner-app { flex-direction: column; height: auto; min-height: 100vh; }
+
+  /* Barra lateral vira navegacao no topo */
+  .barra-lateral {
+    width: 100%;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    padding: 12px 16px;
+    border-right: none;
+    border-bottom: 1px solid var(--borda);
+  }
+  .logotipo { padding: 0; }
+  .menu-navegacao { flex-direction: row; flex: 1 1 100%; overflow-x: auto; gap: 4px; margin-top: 10px; padding-bottom: 4px; }
+  .item-navegacao { margin: 0; white-space: nowrap; flex: 0 0 auto; }
+  .btn-novo { margin: 0 0 0 auto; width: auto; white-space: nowrap; }
+  .menu-inferior { border-top: none; padding-top: 0; }
+
+  .conteudo-principal { padding: 16px; overflow: visible; }
+  .barra-superior { flex-wrap: wrap; gap: 12px; }
+  .barra-superior-esq,
+  .barra-superior-dir { gap: 12px; flex-wrap: wrap; }
+
+  .grade-painel,
+  .dashboard-grid,
+  .grade-kpi,
+  .stats-grid { grid-template-columns: 1fr; }
+
+  /* Modais ocupam a tela com margem */
+  .modal-fundo { padding: 16px; }
+  .modal-conteudo { max-height: 90vh; overflow-y: auto; }
+}
+
+/* Celular */
+@media (max-width: 480px) {
+  .stats-grid { grid-template-columns: 1fr 1fr; }
+  .barra-superior-esq h1 { font-size: 1.25rem; }
+}

--- a/projeto_integrador/lider/avaliacoes.css
+++ b/projeto_integrador/lider/avaliacoes.css
@@ -383,3 +383,61 @@ body {
   background-color: var(--fundo-lateral);
   border-radius: 0 0 12px 12px;
 }
+
+/* ============================================================
+   RESPONSIVIDADE
+   Adapta o layout para tablet, notebook e celular mantendo o
+   design original. Cobre todas as grades usadas nas paginas de
+   colaborador e lider (.grade-painel, .grade-kpi, .dashboard-grid,
+   .stats-grid) e os modais.
+   ============================================================ */
+
+/* Notebook / telas medias */
+@media (max-width: 1024px) {
+  .conteudo-principal { padding: 24px 28px; }
+  .grade-painel,
+  .dashboard-grid { grid-template-columns: 1fr; }
+  .grade-kpi { grid-template-columns: repeat(2, 1fr); }
+}
+
+/* Tablet */
+@media (max-width: 768px) {
+  body { height: auto; }
+  .conteiner-app { flex-direction: column; height: auto; min-height: 100vh; }
+
+  /* Barra lateral vira navegacao no topo */
+  .barra-lateral {
+    width: 100%;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    padding: 12px 16px;
+    border-right: none;
+    border-bottom: 1px solid var(--borda);
+  }
+  .logotipo { padding: 0; }
+  .menu-navegacao { flex-direction: row; flex: 1 1 100%; overflow-x: auto; gap: 4px; margin-top: 10px; padding-bottom: 4px; }
+  .item-navegacao { margin: 0; white-space: nowrap; flex: 0 0 auto; }
+  .btn-novo { margin: 0 0 0 auto; width: auto; white-space: nowrap; }
+  .menu-inferior { border-top: none; padding-top: 0; }
+
+  .conteudo-principal { padding: 16px; overflow: visible; }
+  .barra-superior { flex-wrap: wrap; gap: 12px; }
+  .barra-superior-esq,
+  .barra-superior-dir { gap: 12px; flex-wrap: wrap; }
+
+  .grade-painel,
+  .dashboard-grid,
+  .grade-kpi,
+  .stats-grid { grid-template-columns: 1fr; }
+
+  /* Modais ocupam a tela com margem */
+  .modal-fundo { padding: 16px; }
+  .modal-conteudo { max-height: 90vh; overflow-y: auto; }
+}
+
+/* Celular */
+@media (max-width: 480px) {
+  .stats-grid { grid-template-columns: 1fr 1fr; }
+  .barra-superior-esq h1 { font-size: 1.25rem; }
+}

--- a/projeto_integrador/lider/dashboard.css
+++ b/projeto_integrador/lider/dashboard.css
@@ -242,3 +242,61 @@ body {
   background-color: var(--fundo-ativo);
   border-radius: 8px;
 }
+
+/* ============================================================
+   RESPONSIVIDADE
+   Adapta o layout para tablet, notebook e celular mantendo o
+   design original. Cobre todas as grades usadas nas paginas de
+   colaborador e lider (.grade-painel, .grade-kpi, .dashboard-grid,
+   .stats-grid) e os modais.
+   ============================================================ */
+
+/* Notebook / telas medias */
+@media (max-width: 1024px) {
+  .conteudo-principal { padding: 24px 28px; }
+  .grade-painel,
+  .dashboard-grid { grid-template-columns: 1fr; }
+  .grade-kpi { grid-template-columns: repeat(2, 1fr); }
+}
+
+/* Tablet */
+@media (max-width: 768px) {
+  body { height: auto; }
+  .conteiner-app { flex-direction: column; height: auto; min-height: 100vh; }
+
+  /* Barra lateral vira navegacao no topo */
+  .barra-lateral {
+    width: 100%;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    padding: 12px 16px;
+    border-right: none;
+    border-bottom: 1px solid var(--borda);
+  }
+  .logotipo { padding: 0; }
+  .menu-navegacao { flex-direction: row; flex: 1 1 100%; overflow-x: auto; gap: 4px; margin-top: 10px; padding-bottom: 4px; }
+  .item-navegacao { margin: 0; white-space: nowrap; flex: 0 0 auto; }
+  .btn-novo { margin: 0 0 0 auto; width: auto; white-space: nowrap; }
+  .menu-inferior { border-top: none; padding-top: 0; }
+
+  .conteudo-principal { padding: 16px; overflow: visible; }
+  .barra-superior { flex-wrap: wrap; gap: 12px; }
+  .barra-superior-esq,
+  .barra-superior-dir { gap: 12px; flex-wrap: wrap; }
+
+  .grade-painel,
+  .dashboard-grid,
+  .grade-kpi,
+  .stats-grid { grid-template-columns: 1fr; }
+
+  /* Modais ocupam a tela com margem */
+  .modal-fundo { padding: 16px; }
+  .modal-conteudo { max-height: 90vh; overflow-y: auto; }
+}
+
+/* Celular */
+@media (max-width: 480px) {
+  .stats-grid { grid-template-columns: 1fr 1fr; }
+  .barra-superior-esq h1 { font-size: 1.25rem; }
+}

--- a/projeto_integrador/lider/index.css
+++ b/projeto_integrador/lider/index.css
@@ -450,3 +450,61 @@ body {
   background-color: var(--fundo-lateral);
   border-radius: 0 0 12px 12px;
 }
+
+/* ============================================================
+   RESPONSIVIDADE
+   Adapta o layout para tablet, notebook e celular mantendo o
+   design original. Cobre todas as grades usadas nas paginas de
+   colaborador e lider (.grade-painel, .grade-kpi, .dashboard-grid,
+   .stats-grid) e os modais.
+   ============================================================ */
+
+/* Notebook / telas medias */
+@media (max-width: 1024px) {
+  .conteudo-principal { padding: 24px 28px; }
+  .grade-painel,
+  .dashboard-grid { grid-template-columns: 1fr; }
+  .grade-kpi { grid-template-columns: repeat(2, 1fr); }
+}
+
+/* Tablet */
+@media (max-width: 768px) {
+  body { height: auto; }
+  .conteiner-app { flex-direction: column; height: auto; min-height: 100vh; }
+
+  /* Barra lateral vira navegacao no topo */
+  .barra-lateral {
+    width: 100%;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    padding: 12px 16px;
+    border-right: none;
+    border-bottom: 1px solid var(--borda);
+  }
+  .logotipo { padding: 0; }
+  .menu-navegacao { flex-direction: row; flex: 1 1 100%; overflow-x: auto; gap: 4px; margin-top: 10px; padding-bottom: 4px; }
+  .item-navegacao { margin: 0; white-space: nowrap; flex: 0 0 auto; }
+  .btn-novo { margin: 0 0 0 auto; width: auto; white-space: nowrap; }
+  .menu-inferior { border-top: none; padding-top: 0; }
+
+  .conteudo-principal { padding: 16px; overflow: visible; }
+  .barra-superior { flex-wrap: wrap; gap: 12px; }
+  .barra-superior-esq,
+  .barra-superior-dir { gap: 12px; flex-wrap: wrap; }
+
+  .grade-painel,
+  .dashboard-grid,
+  .grade-kpi,
+  .stats-grid { grid-template-columns: 1fr; }
+
+  /* Modais ocupam a tela com margem */
+  .modal-fundo { padding: 16px; }
+  .modal-conteudo { max-height: 90vh; overflow-y: auto; }
+}
+
+/* Celular */
+@media (max-width: 480px) {
+  .stats-grid { grid-template-columns: 1fr 1fr; }
+  .barra-superior-esq h1 { font-size: 1.25rem; }
+}

--- a/projeto_integrador/lider/relatorios.css
+++ b/projeto_integrador/lider/relatorios.css
@@ -362,3 +362,61 @@ body {
   background-color: var(--fundo-lateral);
   border-radius: 0 0 12px 12px;
 }
+
+/* ============================================================
+   RESPONSIVIDADE
+   Adapta o layout para tablet, notebook e celular mantendo o
+   design original. Cobre todas as grades usadas nas paginas de
+   colaborador e lider (.grade-painel, .grade-kpi, .dashboard-grid,
+   .stats-grid) e os modais.
+   ============================================================ */
+
+/* Notebook / telas medias */
+@media (max-width: 1024px) {
+  .conteudo-principal { padding: 24px 28px; }
+  .grade-painel,
+  .dashboard-grid { grid-template-columns: 1fr; }
+  .grade-kpi { grid-template-columns: repeat(2, 1fr); }
+}
+
+/* Tablet */
+@media (max-width: 768px) {
+  body { height: auto; }
+  .conteiner-app { flex-direction: column; height: auto; min-height: 100vh; }
+
+  /* Barra lateral vira navegacao no topo */
+  .barra-lateral {
+    width: 100%;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    padding: 12px 16px;
+    border-right: none;
+    border-bottom: 1px solid var(--borda);
+  }
+  .logotipo { padding: 0; }
+  .menu-navegacao { flex-direction: row; flex: 1 1 100%; overflow-x: auto; gap: 4px; margin-top: 10px; padding-bottom: 4px; }
+  .item-navegacao { margin: 0; white-space: nowrap; flex: 0 0 auto; }
+  .btn-novo { margin: 0 0 0 auto; width: auto; white-space: nowrap; }
+  .menu-inferior { border-top: none; padding-top: 0; }
+
+  .conteudo-principal { padding: 16px; overflow: visible; }
+  .barra-superior { flex-wrap: wrap; gap: 12px; }
+  .barra-superior-esq,
+  .barra-superior-dir { gap: 12px; flex-wrap: wrap; }
+
+  .grade-painel,
+  .dashboard-grid,
+  .grade-kpi,
+  .stats-grid { grid-template-columns: 1fr; }
+
+  /* Modais ocupam a tela com margem */
+  .modal-fundo { padding: 16px; }
+  .modal-conteudo { max-height: 90vh; overflow-y: auto; }
+}
+
+/* Celular */
+@media (max-width: 480px) {
+  .stats-grid { grid-template-columns: 1fr 1fr; }
+  .barra-superior-esq h1 { font-size: 1.25rem; }
+}

--- a/projeto_integrador/login/style.css
+++ b/projeto_integrador/login/style.css
@@ -212,11 +212,45 @@ body, html {
 }
 
 /* Responsividade */
+
+/* Notebook / telas medias */
+@media (max-width: 1024px) {
+    .bloco-imagem img { height: 12rem; }
+    .conteudo-centralizado { max-width: 400px; }
+}
+
+/* Tablet: empilha os paineis e libera a rolagem */
 @media (max-width: 768px) {
+    body, html {
+        height: auto;
+        overflow: auto;
+    }
     .container {
         flex-direction: column;
+        min-height: 100%;
     }
     .painel-esquerdo, .painel-direito {
-        padding: 2rem;
+        flex: none;
+        width: 100%;
+        padding: 2.5rem 2rem;
     }
+    .conteudo-centralizado,
+    .conteudo-login {
+        height: auto;
+        max-width: 460px;
+        margin: 0 auto;
+    }
+    .rodape-login { padding-top: 2rem; }
+}
+
+/* Celular */
+@media (max-width: 480px) {
+    .painel-esquerdo, .painel-direito {
+        padding: 1.75rem 1.25rem;
+    }
+    .logo h1 { font-size: 1.5rem; }
+    .bloco-imagem img { height: 10rem; }
+    .texto-esquerdo h2,
+    .painel-direito h2 { font-size: 1.3rem; }
+    .painel-direito p { margin-bottom: 2rem; }
 }


### PR DESCRIPTION
Adiciona media queries (1024px, 768px e 480px) a todas as paginas mantendo o design original, para que o site funcione em celular, tablet, notebook e PC.

- admin/colaborador/lider: sidebar vira navegacao no topo no mobile, grades de stats/cards colapsam para 1-2 colunas, topbar e busca ajustam para largura total, modais ganham margem e rolagem.
- login: paineis empilham e liberam rolagem no mobile.