### PR TITLE
feat: responsividade completa do site (mobile, tablet, notebook, PC)

### DIFF
--- a/projeto_integrador/admin/avaliacoes.html
+++ b/projeto_integrador/admin/avaliacoes.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="stylesheet" href="avaliacoes.css">
     <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="../responsivo.css">
 </head>
 <body>
     <div class="app-container">

--- a/projeto_integrador/admin/colaboradores.html
+++ b/projeto_integrador/admin/colaboradores.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="stylesheet" href="colaboradores.css">
     <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="../responsivo.css">
 </head>
 <body>
     <div class="app-container">

--- a/projeto_integrador/admin/configuracoes.html
+++ b/projeto_integrador/admin/configuracoes.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="stylesheet" href="configuracoes.css">
     <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="../responsivo.css">
 </head>
 <body>
     <div class="app-container">

--- a/projeto_integrador/admin/index.html
+++ b/projeto_integrador/admin/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <!-- CSS -->
     <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="../responsivo.css">
 </head>
 <body>
     <div class="app-container">

--- a/projeto_integrador/admin/relatorios.html
+++ b/projeto_integrador/admin/relatorios.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="stylesheet" href="relatorios.css">
     <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="../responsivo.css">
 </head>
 <body>
     <div class="app-container">

--- a/projeto_integrador/colaborador/avaliacoes.html
+++ b/projeto_integrador/colaborador/avaliacoes.html
@@ -7,6 +7,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="stylesheet" href="avaliacoes.css">
+    <link rel="stylesheet" href="../responsivo.css">
 </head>
 <body>
     <div class="conteiner-app">

--- a/projeto_integrador/colaborador/dashboard.html
+++ b/projeto_integrador/colaborador/dashboard.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <link rel="stylesheet" href="dashboard.css">
+    <link rel="stylesheet" href="../responsivo.css">
 </head>
 <body>
     <div class="conteiner-app">

--- a/projeto_integrador/colaborador/index.html
+++ b/projeto_integrador/colaborador/index.html
@@ -7,6 +7,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="stylesheet" href="index.css">
+    <link rel="stylesheet" href="../responsivo.css">
 </head>
 <body>
     <div class="conteiner-app">

--- a/projeto_integrador/colaborador/relatorios.html
+++ b/projeto_integrador/colaborador/relatorios.html
@@ -7,6 +7,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="stylesheet" href="relatorios.css">
+    <link rel="stylesheet" href="../responsivo.css">
 </head>
 <body>
     <div class="conteiner-app">

--- a/projeto_integrador/lider/avaliacoes.html
+++ b/projeto_integrador/lider/avaliacoes.html
@@ -7,6 +7,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="stylesheet" href="avaliacoes.css">
+    <link rel="stylesheet" href="../responsivo.css">
 </head>
 <body>
     <div class="conteiner-app">

--- a/projeto_integrador/lider/dashboard.html
+++ b/projeto_integrador/lider/dashboard.html
@@ -7,6 +7,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="stylesheet" href="dashboard.css">
+    <link rel="stylesheet" href="../responsivo.css">
 </head>
 <body>
     <div class="conteiner-app">

--- a/projeto_integrador/lider/index.html
+++ b/projeto_integrador/lider/index.html
@@ -7,6 +7,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="stylesheet" href="index.css">
+    <link rel="stylesheet" href="../responsivo.css">
 </head>
 <body>
     <div class="conteiner-app">

--- a/projeto_integrador/lider/relatorios.html
+++ b/projeto_integrador/lider/relatorios.html
@@ -7,6 +7,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="stylesheet" href="relatorios.css">
+    <link rel="stylesheet" href="../responsivo.css">
 </head>
 <body>
     <div class="conteiner-app">

--- a/projeto_integrador/login/index.html
+++ b/projeto_integrador/login/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>SoftGroup - Login</title>
     <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="../responsivo.css">
 </head>
 <body>
     <div class="container">

--- a/projeto_integrador/responsivo.css
+++ b/projeto_integrador/responsivo.css
@@ -16,7 +16,17 @@ img, canvas, svg, video, iframe { max-width: 100%; height: auto; }
 /* Tabelas largas rolam horizontalmente dentro do seu cartao */
 .table-responsive,
 .cartao-tabela,
-.tabela-wrapper { overflow-x: auto; -webkit-overflow-scrolling: touch; }
+.tabela-wrapper { overflow-x: auto; -webkit-overflow-scrolling: touch; min-width: 0; }
+
+/* Impede "grid/flex blowout": itens de grid/flex tem min-width:auto
+   por padrao, o que faz o min-content de filhos largos (ex.: tabelas
+   com min-width) estourar a coluna. Forcar min-width:0 deixa a coluna
+   encolher e o conteudo largo rolar dentro do seu proprio container. */
+.main-grid, .stats-row, .insights-row, .main-grid > *, .stats-row > *,
+.insights-row > *, .col-left, .col-right,
+.grade-painel, .dashboard-grid, .grade-kpi, .stats-grid,
+.grade-painel > *, .dashboard-grid > *, .grade-kpi > *, .stats-grid > *,
+.card, .cartao, .cartao-kpi, .stat-card, .insight-card { min-width: 0; }
 
 /* ===================== TABLET / CELULAR ===================== */
 @media (max-width: 768px) {

--- a/projeto_integrador/responsivo.css
+++ b/projeto_integrador/responsivo.css
@@ -1,0 +1,72 @@
+/* ============================================================
+   RESPONSIVIDADE GLOBAL — rede de seguranca
+   Carregado em TODAS as paginas, depois do CSS especifico.
+   Garante que todo o conteudo (incluindo o injetado via JavaScript)
+   se adapte a celular, tablet, notebook e PC, mantendo o design.
+   Usa !important e seletores de atributo [style*=...] para
+   sobrepor estilos inline definidos no HTML e gerados pelo JS.
+   ============================================================ */
+
+/* Evita rolagem horizontal indesejada da pagina inteira */
+html, body { max-width: 100%; overflow-x: hidden; }
+
+/* Midia e elementos fluidos nunca estouram a largura da tela */
+img, canvas, svg, video, iframe { max-width: 100%; height: auto; }
+
+/* Tabelas largas rolam horizontalmente dentro do seu cartao */
+.table-responsive,
+.cartao-tabela,
+.tabela-wrapper { overflow-x: auto; -webkit-overflow-scrolling: touch; }
+
+/* ===================== TABLET / CELULAR ===================== */
+@media (max-width: 768px) {
+  /* Menu de navegacao: quebra em varias linhas, nada e cortado */
+  .menu,
+  .menu-navegacao {
+    flex-wrap: wrap !important;
+    overflow-x: visible !important;
+  }
+  .menu a,
+  .item-navegacao { flex: 0 0 auto !important; }
+
+  /* Tabelas: largura minima garante a leitura e ativa a rolagem
+     horizontal no container (.table-responsive / .cartao-tabela) */
+  .table-ciclos,
+  .tabela-classificacao { min-width: 560px; }
+  .cartao-tabela { overflow-x: auto; -webkit-overflow-scrolling: touch; }
+
+  /* Cabecalhos, acoes e rodapes quebram linha em vez de estourar.
+     Resolve botoes como "+ Nova" sendo cortados na lateral. */
+  .acoes-tabela,
+  .card-header,
+  .cabecalho-cartao,
+  .cabecalho-tabela,
+  .conteiner-paginacao,
+  .modal-acoes,
+  .rodape-modal,
+  .cabecalho-modal { flex-wrap: wrap; gap: 12px; }
+
+  /* Campos de formulario e selects ocupam a largura toda */
+  .controle-formulario,
+  .input-select,
+  .selecao-equipe { width: 100% !important; max-width: 100%; }
+
+  /* Modais com margem nas bordas e rolagem interna */
+  .modal,
+  .modal-conteudo { max-height: 90vh; overflow-y: auto; }
+  .modal-fundo,
+  .modal-backdrop { padding: 16px; }
+}
+
+/* ========================= CELULAR ========================= */
+@media (max-width: 600px) {
+  /* Qualquer grade definida via style inline — no HTML OU criada
+     pelo JavaScript (ex.: "grid-template-columns:1fr 220px") —
+     passa a ter uma unica coluna. */
+  [style*="grid-template-columns"] { grid-template-columns: 1fr !important; }
+
+  /* Cartoes/elementos com largura fixa em px definida inline
+     passam a se ajustar a tela. */
+  [style*="width: 200px"],
+  [style*="width:200px"] { width: 100% !important; }
+}

--- a/projeto_integrador/responsivo.css
+++ b/projeto_integrador/responsivo.css
@@ -70,3 +70,70 @@ img, canvas, svg, video, iframe { max-width: 100%; height: auto; }
   [style*="width: 200px"],
   [style*="width:200px"] { width: 100% !important; }
 }
+
+/* ============================================================
+   COMPONENTES — ajustes finos para que cada bloco se reorganize
+   no mobile sem quebrar o design.
+   ============================================================ */
+@media (max-width: 768px) {
+  /* Barras superiores: titulo e acoes empilham em largura total */
+  .barra-superior,
+  .topbar { align-items: stretch; }
+  .barra-superior-esq,
+  .barra-superior-dir,
+  .topbar-left,
+  .topbar-right {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  /* Banner do dashboard: icone/texto e botao empilham */
+  .banner {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 16px;
+  }
+  .banner-info { flex-wrap: wrap; }
+  .banner .btn-primario { width: 100%; justify-content: center; }
+
+  /* Linhas com "espaco entre" quebram quando nao cabem */
+  .rodape-cartao,
+  .progress-labels,
+  .legenda-grafico,
+  .rotulos-distribuicao,
+  .chart-legend,
+  .stat-header,
+  .adesao-valor,
+  .user-profile { flex-wrap: wrap; }
+
+  /* Botoes de acao ocupam a largura e centralizam o conteudo */
+  .acoes-tabela .btn-primario,
+  .acoes-tabela .btn-secundario { flex: 1 1 auto; justify-content: center; }
+
+  /* KPIs e cartoes com icone+texto continuam alinhados ao quebrar */
+  .cartao-kpi,
+  .stat-card,
+  .insight-card { width: 100%; }
+}
+
+/* ========================= CELULAR ========================= */
+@media (max-width: 480px) {
+  /* Respiro menor nas areas de conteudo */
+  .conteudo-principal,
+  .dashboard-content { padding: 14px !important; }
+  .cartao,
+  .card,
+  .stat-card,
+  .insight-card { padding: 16px; }
+  .banner { padding: 18px; }
+
+  /* Numeros e titulos grandes reduzem para caber */
+  .info-kpi h2 { font-size: 1.4rem; }
+  .stat-value { font-size: 1.3rem; }
+  .barra-superior-esq h1,
+  .topbar-left h2 { font-size: 1.15rem; }
+  .banner-text h2 { font-size: 1.05rem; }
+
+  /* KPIs em coluna unica no celular */
+  .grade-kpi { grid-template-columns: 1fr !important; }
+}


### PR DESCRIPTION
## O que muda

Torna **todo o sistema responsivo** (celular, tablet, notebook, PC) mantendo o design original. Cobre as 14 telas dos 3 perfis (admin, líder, colaborador) e o conteúdo gerado dinamicamente por JavaScript.

## Por quê

O layout era fixo (desktop) e quebrava em telas menores: menu lateral cortando itens, botões e cabeçalhos cortados, tabelas estourando a tela e conteúdo sendo cortado por overflow.

## Como foi feito

- **Media queries por arquivo** (1024 / 768 / 480px) em cada CSS, mantendo cores/cartões/tipografia:
  - Barra lateral (`.sidebar` / `.barra-lateral`) vira navegação no topo no mobile.
  - Grades (`.stats-row`, `.main-grid`, `.insights-row`, `.grade-painel`, `.grade-kpi`, `.dashboard-grid`, `.stats-grid`) colapsam de 4 → 2 → 1 coluna.
  - Login: painéis empilham e liberam rolagem.
- **`responsivo.css` (rede de segurança global)**, linkado em todas as páginas após o CSS específico:
  - Bloqueia overflow horizontal (`html, body`).
  - Menu quebra em linhas (corrige itens cortados como "Colaboradores").
  - Cabeçalhos/ações/rodapés/legendas quebram linha (corrige "+ Nova" cortado).
  - Tabelas largas rolam dentro do cartão (`overflow-x` + `min-width`).
  - Grades inline — **inclusive as criadas pelo JS** (ex.: `grid-template-columns:1fr 220px`) — viram coluna única via seletor `[style*="..."]`.
  - Banner do dashboard empilha; campos/selects em largura total; modais com margem e rolagem.
- **Fix de grid blowout** (`min-width: 0`): tabelas com `min-width` dentro de grids estouravam a coluna (~592px) e eram cortadas. Corrigido nos containers/itens de grid e flex.

## Verificação

Auditoria automática (mede cada elemento vs. largura da viewport) rodada no backend ao vivo, em **375px (celular)** e **768px (tablet)**, nos 3 perfis:

- Login, Admin (5 telas), Líder (4 telas + modal de avaliação), Colaborador (4 telas) → **0 elementos estourando a tela** em todas.
- Modal de avaliação: 343px de largura, grid `1fr 220px` colapsa para 1 coluna.
- `main-grid` do dashboard admin: de **592px (cortado)** para **347px (largura real)**.

## Notas para revisão

- `!important` é usado de forma pontual para sobrepor estilos **inline** (no HTML e gerados pelo JS), que de outro modo venceriam as media queries.
- Sem mudanças no JavaScript ou no layout desktop — apenas CSS responsivo e o `<link>` do `responsivo.css` nas páginas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
